### PR TITLE
Readme: Use Issues tab for your specific dev account or extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-This **MicrosoftEdge-Extensions** repo contains sample code, issues, and discussions about Microsoft Edge extensions (add-ons).
+Use this **MicrosoftEdge-Extensions** repo as a community space.  This **MicrosoftEdge-Extensions** repo contains sample code, issues, and discussions about Microsoft Edge extensions (add-ons).
 
 [Microsoft Edge Add-ons](https://microsoftedge.microsoft.com/addons/Microsoft-Edge-Extensions-Home) is the store for Microsoft Edge extensions, where you can publish your Microsoft Edge extensions and make them available to Microsoft Edge users.
 
@@ -6,55 +6,74 @@ This **MicrosoftEdge-Extensions** repo contains sample code, issues, and discuss
 
 
 <!-- ====================================================================== -->
-## About the MicrosoftEdge-Extensions repo
+## Code
 
-Use this **MicrosoftEdge-Extensions** repo as a community space.
+Use the [Code](https://github.com/microsoft/MicrosoftEdge-Extensions/tree/main/Extension-samples) page of this **MicrosoftEdge-Extensions** repo to access sample code to learn how to build Microsoft Edge extensions.
 
-* Use the [Code](https://github.com/microsoft/MicrosoftEdge-Extensions/tree/main/Extension-samples) tab to:
-
-  * Access sample code to learn how to build Microsoft Edge extensions.
-
-* Use the [Issues](https://github.com/microsoft/MicrosoftEdge-Extensions/issues) tab to:
-
-  * Inquire about your Microsoft Edge add-ons developer account.
-
-  * Inquire about the review status or certification status of your Edge extension after submitting the extension via Partner Center.
-
-  * Report any bugs or issues about Microsoft Partner Center or [Microsoft Edge Add-ons](https://microsoftedge.microsoft.com/addons/Microsoft-Edge-Extensions-Home) which affect all developers or all Microsoft Edge users.
-
-  * Suggest new features that could impact or benefit all Microsoft Edge extension developers.
-
-  * Connect with other extension developers about technical questions related to building Microsoft Edge extensions.
-
-* Use the [Discussions](https://github.com/microsoft/MicrosoftEdge-Extensions/discussions) tab to:
-
-  * Follow the latest announcements and updates from the Microsoft Edge extensions team.
-
-  * Share input or suggestions with the Microsoft Edge extensions team about how to improve extension publishing, management and listing processes or workflows.
-
-  * Provide early feedback to the Microsoft Edge extensions team about any new features for extensions publishing, extensions management, or processes or workflows for extensions listings.
-
-  * Share best practices with other developers on building, managing or acquiring more users for their browser extension.
-
-  * Share questions or answer other developers' questions about building or publishing Microsoft Edge extensions.
-
-  * Share tips and tricks with other developers.
-
-See also:
-* [Communicating on GitHub](https://docs.github.com/en/get-started/using-github/communicating-on-github) - When to use **Issues** vs. **Discussions**.
-
-
-<!-- ====================================================================== -->
-## Samples
-
-The **Code** tab of the **MicrosoftEdge-Extensions** repo contains the following samples:
+This repo contains the following samples:
 
 | Name | Folder | Article |
 | --- | --- | --- |
 | Picture viewer pop-up webpage | [/picture-viewer-popup-webpage/](https://github.com/microsoft/MicrosoftEdge-Extensions/tree/main/Extension-samples/picture-viewer-popup-webpage) | [Sample: Picture viewer pop-up webpage](https://learn.microsoft.com/microsoft-edge/extensions-chromium/getting-started/picture-viewer-popup-webpage) |
 | Picture inserter using content script | [/picture-inserter-content-script/](https://github.com/microsoft/MicrosoftEdge-Extensions/tree/main/Extension-samples/picture-inserter-content-script) | [Sample: Picture inserter using content script](https://learn.microsoft.com/microsoft-edge/extensions-chromium/getting-started/picture-inserter-content-script) |
 
-The files at [TestCrxPackages](https://github.com/microsoft/MicrosoftEdge-Extensions/tree/main/Extension-samples/TestCrxPackages) are test extension packages and should be ignored.
+The files at [TestCrxPackages](https://github.com/microsoft/MicrosoftEdge-Extensions/tree/main/Extension-samples/TestCrxPackages) are test extension packages, and you can ignore them.
+
+
+<!-- ====================================================================== -->
+## Issues
+<!-- sync:
+https://learn.microsoft.com/microsoft-edge/extensions-chromium/publish/contact-extensions-team#issues-page-in-the-microsoftedge-extensions-repo
+https://github.com/microsoft/MicrosoftEdge-Extensions/blob/main/README.md#issues
+-->
+
+To report or discuss an issue about extensions, use the [Issues](https://github.com/microsoft/MicrosoftEdge-Extensions/issues) page in this **MicrosoftEdge-Extensions** repo.
+
+Use the **Issues** page to:
+
+* Report bugs or issues about [Microsoft Edge Add-ons](https://microsoftedge.microsoft.com/addons/) (the store) that affect all Edge extension developers or all Microsoft Edge extension users.
+
+* Report bugs or issues about Microsoft Partner Center that affect all Edge extension developers or all Microsoft Edge extension users.
+
+* Inquire about your Partner Center developer account for Microsoft Edge extensions.
+
+* Inquire about the review status or certification status of your Edge extension after submitting the extension via Partner Center.
+
+* Suggest new features that could impact or benefit all Microsoft Edge extension developers.
+
+* Connect with other extension developers about technical questions related to building Microsoft Edge extensions.
+
+* Ask about aspects of extensions that affect all extension developers or all Microsoft Edge extension users.
+
+See also:
+* [GitHub Issues](https://docs.github.com/get-started/using-github/communicating-on-github#github-issues) in _Communicating on GitHub_.
+* [Scenarios for issues](https://docs.github.com/get-started/using-github/communicating-on-github#scenarios-for-issues) in _Communicating on GitHub_.
+
+
+<!-- ====================================================================== -->
+## Discussions
+<!-- sync:
+https://learn.microsoft.com/microsoft-edge/extensions-chromium/publish/contact-extensions-team#discussion-forum-in-the-microsoftedge-extensions-repo
+https://github.com/microsoft/MicrosoftEdge-Extensions/blob/main/README.md#discussions
+-->
+
+Use the [Discussions](https://github.com/microsoft/MicrosoftEdge-Extensions/discussions) page of this **MicrosoftEdge-Extensions** repo for:
+
+* Discussing with the Extensions team:
+  * Follow the latest announcements and updates from the Microsoft Edge extensions team.
+  * Request a feature for Edge extensions.
+  * Discuss how to improve UI features that are at [Microsoft Edge Add-ons](https://microsoftedge.microsoft.com/addons/).
+  * Discuss how to improve extension publishing, management and listing processes or workflows.
+  * Provide feedback about features for extensions publishing, extensions management, or processes or workflows for extensions listings.
+
+* Discussing with other extension developers:
+  * Discuss technical questions about developing an Edge extension.
+  * Share best practices, tips, and tricks with other developers on building, publishing, managing, or acquiring more users for their browser extension.
+  * Share ideas about features for Microsoft Edge extensions.
+
+See also:
+* [GitHub Discussions](https://docs.github.com/get-started/using-github/communicating-on-github#github-discussions) in _Communicating on GitHub_.
+* [Scenarios for GitHub Discussions](https://docs.github.com/get-started/using-github/communicating-on-github#scenarios-for-github-discussions) in _Communicating on GitHub_.
 
 
 <!-- ====================================================================== -->

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 This **MicrosoftEdge-Extensions** repo contains sample code, issues, and discussions about Microsoft Edge extensions (add-ons).
 
-The [Edge Add-ons](https://microsoftedge.microsoft.com/addons/Microsoft-Edge-Extensions-Home) website is the store for Microsoft Edge extensions, where browser extension developers can publish their Microsoft Edge add-ons and make them available to Microsoft Edge users.
+[Microsoft Edge Add-ons](https://microsoftedge.microsoft.com/addons/Microsoft-Edge-Extensions-Home) is the store for Microsoft Edge extensions, where you can publish your Microsoft Edge extensions and make them available to Microsoft Edge users.
 
-The [Microsoft Edge Add-ons Developer](https://developer.microsoft.com/microsoft-edge/extensions/) portal is a central place to find all information and resources for Microsoft Edge extension developers.
+[Microsoft Edge Add-ons Developer](https://developer.microsoft.com/microsoft-edge/extensions/) is a central portal for information and resources for developing Microsoft Edge extensions.
 
 
 <!-- ====================================================================== -->
@@ -10,39 +10,35 @@ The [Microsoft Edge Add-ons Developer](https://developer.microsoft.com/microsoft
 
 Use this **MicrosoftEdge-Extensions** repo as a community space.
 
-**Code** tab:
+* Use the [Code](https://github.com/microsoft/MicrosoftEdge-Extensions/tree/main/Extension-samples) tab to:
 
-* Access resources and sample code to learn how to build Microsoft Edge extensions (add-ons).
+  * Access sample code to learn how to build Microsoft Edge extensions.
 
-**Issues** tab:
+* Use the [Issues](https://github.com/microsoft/MicrosoftEdge-Extensions/issues) tab to:
 
-* Inquire about your Microsoft Edge add-ons developer account.
+  * Inquire about your Microsoft Edge add-ons developer account.
 
-* Inquire about the review status or certification status of your Edge extension after submitting the extension via Partner Center.
+  * Inquire about the review status or certification status of your Edge extension after submitting the extension via Partner Center.
 
-* Connect with other extension developers about technical questions related to building Microsoft Edge add-ons.
+  * Report any bugs or issues about Microsoft Partner Center or [Microsoft Edge Add-ons](https://microsoftedge.microsoft.com/addons/Microsoft-Edge-Extensions-Home) which affect all developers or all Microsoft Edge users.
 
-* Report any bugs or issues about Microsoft Partner Center or the Edge Add-ons website which affect all developers or all Microsoft Edge users.
+  * Suggest new features that could impact or benefit all Microsoft Edge extension developers.
 
-**Discussions** tab:
+  * Connect with other extension developers about technical questions related to building Microsoft Edge extensions.
 
-* Share inputs or suggestions to the Microsoft Edge add-ons engineering team on how to improve extension publishing, management and listing processes or workflows.
+* Use the [Discussions](https://github.com/microsoft/MicrosoftEdge-Extensions/discussions) tab to:
 
-* Provide early feedback to the Microsoft Edge add-ons engineering team about any new features for extensions publishing, extensions management, or processes or workflows for extensions listings.
+  * Follow the latest announcements and updates from the Microsoft Edge extensions team.
 
-* Share best practices with other developers on building, managing or acquiring more users for their browser extension.
+  * Share input or suggestions with the Microsoft Edge extensions team about how to improve extension publishing, management and listing processes or workflows.
 
+  * Provide early feedback to the Microsoft Edge extensions team about any new features for extensions publishing, extensions management, or processes or workflows for extensions listings.
 
-<!-- ====================================================================== -->
-## Community resources
+  * Share best practices with other developers on building, managing or acquiring more users for their browser extension.
 
-The **MicrosoftEdge-Extensions** repo includes the following tabs:
+  * Share questions or answer other developers' questions about building or publishing Microsoft Edge extensions.
 
-| Tab | Purpose |
-| ------------ | ------------ |
-| [Code](https://github.com/microsoft/MicrosoftEdge-Extensions/tree/main/Extension-samples) | Sample code for Microsoft Edge extensions (add-ons). |
-| [Issues](https://github.com/microsoft/MicrosoftEdge-Extensions/issues) | Use this forum to report bugs or suggest new features that could impact or benefit all Microsoft Edge extension developers, or inquire about your developer account or extension status. |
-| [Discussions](https://github.com/microsoft/MicrosoftEdge-Extensions/discussions) | Use this forum to share questions or answer other developers' questions about building or publishing Microsoft Edge add-ons, follow the latest announcements and updates from the Microsoft Edge add-ons team, and share tips and tricks with other developers. |
+  * Share tips and tricks with other developers.
 
 
 <!-- ====================================================================== -->
@@ -61,7 +57,7 @@ The files at [TestCrxPackages](https://github.com/microsoft/MicrosoftEdge-Extens
 <!-- ====================================================================== -->
 ## Stay connected
 
-You can follow what's happening with Microsoft Edge add-ons via [#EdgeExtensions at Twitter](https://x.com/search?q=%23EdgeExtensions&src=typed_query&f=live).
+You can follow what's happening with Microsoft Edge extensions via [#EdgeExtensions at Twitter](https://x.com/search?q=%23EdgeExtensions&src=typed_query&f=live).
 <!-- possible link: https://x.com/msedgedev/ -->
 
 You can also stay tuned to recent updates and announcements via the [Microsoft Edge Insider](https://techcommunity.microsoft.com/category/MicrosoftEdgeInsider) product community at Tech Community, or search there for [Edge extensions](https://techcommunity.microsoft.com/search?q=edge+extensions&location=category%3AMicrosoftEdgeInsider)<!-- 1269 --> or [Edge add-on](https://techcommunity.microsoft.com/search?q=edge+add-on&location=category%3AMicrosoftEdgeInsider).<!-- 1108 -->
@@ -78,8 +74,8 @@ See also:
 * [Supported APIs for Microsoft Edge extensions](https://learn.microsoft.com/microsoft-edge/extensions-chromium/developer-guide/api-support)
 * [Register as a Microsoft Edge extension developer](https://learn.microsoft.com/microsoft-edge/extensions-chromium/publish/create-dev-account)
 * [Defining match patterns for an extension to access file URLs](https://learn.microsoft.com/microsoft-edge/extensions-chromium/enterprise/match-patterns)
-* [Roadmap for Microsoft Edge Add-ons](https://aka.ms/EdgeAddonsRoadmap)
-* [Released features for Microsoft Edge Add-ons](https://aka.ms/EdgeAddonsReleaseNotes)
+* [Roadmap for Microsoft Edge extensions](https://aka.ms/EdgeAddonsRoadmap)
+* [Released features for Microsoft Edge extensions](https://aka.ms/EdgeAddonsReleaseNotes)
 <!-- the 4 aka links are noted in the destination .md file -->
 
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Use this **MicrosoftEdge-Extensions** repo as a community space.  This repo cont
 
 
 <!-- ====================================================================== -->
-### Code
+## Code
 
 Use the [Code](https://github.com/microsoft/MicrosoftEdge-Extensions/tree/main/Extension-samples) page of this **MicrosoftEdge-Extensions** repo to access sample code to learn how to build Microsoft Edge extensions.
 
@@ -23,7 +23,7 @@ The files at [TestCrxPackages](https://github.com/microsoft/MicrosoftEdge-Extens
 
 
 <!-- ====================================================================== -->
-### Issues
+## Issues
 <!-- sync:
 https://learn.microsoft.com/microsoft-edge/extensions-chromium/publish/contact-extensions-team#issues-page-in-the-microsoftedge-extensions-repo
 https://github.com/microsoft/MicrosoftEdge-Extensions/blob/main/README.md#issues
@@ -48,7 +48,7 @@ See also:
 
 
 <!-- ====================================================================== -->
-### Discussions
+## Discussions
 <!-- sync:
 https://learn.microsoft.com/microsoft-edge/extensions-chromium/publish/contact-extensions-team#discussion-forum-in-the-microsoftedge-extensions-repo
 https://github.com/microsoft/MicrosoftEdge-Extensions/blob/main/README.md#discussions
@@ -74,7 +74,7 @@ See also:
 
 
 <!-- ====================================================================== -->
-### Stay connected
+## Stay connected
 
 You can follow what's happening with Microsoft Edge extensions via [#EdgeExtensions at Twitter](https://x.com/search?q=%23EdgeExtensions&src=typed_query&f=live).
 <!-- possible link: https://x.com/msedgedev/ -->
@@ -86,7 +86,7 @@ See also:
 
 
 <!-- ====================================================================== -->
-### Documentation
+## Documentation
 
 * [Overview of Microsoft Edge extensions](https://aka.ms/AboutEdgeAddons)
 * [Extension concepts and architecture](https://aka.ms/EdgeAddonsLearn)
@@ -99,6 +99,6 @@ See also:
 
 
 <!-- ====================================================================== -->
-### Edge-related issues other than extensions
+## Edge-related issues other than extensions
 
 For Microsoft Edge-related issues other than extensions, see [How to Report a Feedback/Bug to Microsoft Edge's Team?](https://answers.microsoft.com/en-us/microsoftedge/forum/all/how-to-report-a-feedbackbug-to-microsoft-edges/20cc8eb5-11bb-43b6-95d1-e004d41ef876)<!-- /en-us/ required -->

--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ Use this **MicrosoftEdge-Extensions** repo as a community space.
 
   * Share tips and tricks with other developers.
 
+See also:
+* [Communicating on GitHub](https://docs.github.com/en/get-started/using-github/communicating-on-github) - When to use **Issues** vs. **Discussions**.
+
 
 <!-- ====================================================================== -->
 ## Samples

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This repo contains the following samples:
 | Picture viewer pop-up webpage | [/picture-viewer-popup-webpage/](https://github.com/microsoft/MicrosoftEdge-Extensions/tree/main/Extension-samples/picture-viewer-popup-webpage) | [Sample: Picture viewer pop-up webpage](https://learn.microsoft.com/microsoft-edge/extensions-chromium/getting-started/picture-viewer-popup-webpage) |
 | Picture inserter using content script | [/picture-inserter-content-script/](https://github.com/microsoft/MicrosoftEdge-Extensions/tree/main/Extension-samples/picture-inserter-content-script) | [Sample: Picture inserter using content script](https://learn.microsoft.com/microsoft-edge/extensions-chromium/getting-started/picture-inserter-content-script) |
 
-The files at [TestCrxPackages](https://github.com/microsoft/MicrosoftEdge-Extensions/tree/main/Extension-samples/TestCrxPackages) are test extension packages, and you can ignore them.
+The files in [/TestCrxPackages/](https://github.com/microsoft/MicrosoftEdge-Extensions/tree/main/Extension-samples/TestCrxPackages) are test extension packages, and you can ignore them.
 
 
 <!-- ====================================================================== -->

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-Use this **MicrosoftEdge-Extensions** repo as a community space.  This **MicrosoftEdge-Extensions** repo contains sample code, issues, and discussions about Microsoft Edge extensions (add-ons).
+# About the MicrosoftEdge-Extensions repo
+
+Use this **MicrosoftEdge-Extensions** repo as a community space.  This repo contains sample code, issues, and discussions about Microsoft Edge extensions (add-ons).
 
 [Microsoft Edge Add-ons](https://microsoftedge.microsoft.com/addons/Microsoft-Edge-Extensions-Home) is the store for Microsoft Edge extensions, where you can publish your Microsoft Edge extensions and make them available to Microsoft Edge users.
 
@@ -6,7 +8,7 @@ Use this **MicrosoftEdge-Extensions** repo as a community space.  This **Microso
 
 
 <!-- ====================================================================== -->
-## Code
+### Code
 
 Use the [Code](https://github.com/microsoft/MicrosoftEdge-Extensions/tree/main/Extension-samples) page of this **MicrosoftEdge-Extensions** repo to access sample code to learn how to build Microsoft Edge extensions.
 
@@ -21,7 +23,7 @@ The files at [TestCrxPackages](https://github.com/microsoft/MicrosoftEdge-Extens
 
 
 <!-- ====================================================================== -->
-## Issues
+### Issues
 <!-- sync:
 https://learn.microsoft.com/microsoft-edge/extensions-chromium/publish/contact-extensions-team#issues-page-in-the-microsoftedge-extensions-repo
 https://github.com/microsoft/MicrosoftEdge-Extensions/blob/main/README.md#issues
@@ -46,7 +48,7 @@ See also:
 
 
 <!-- ====================================================================== -->
-## Discussions
+### Discussions
 <!-- sync:
 https://learn.microsoft.com/microsoft-edge/extensions-chromium/publish/contact-extensions-team#discussion-forum-in-the-microsoftedge-extensions-repo
 https://github.com/microsoft/MicrosoftEdge-Extensions/blob/main/README.md#discussions
@@ -72,7 +74,7 @@ See also:
 
 
 <!-- ====================================================================== -->
-## Stay connected
+### Stay connected
 
 You can follow what's happening with Microsoft Edge extensions via [#EdgeExtensions at Twitter](https://x.com/search?q=%23EdgeExtensions&src=typed_query&f=live).
 <!-- possible link: https://x.com/msedgedev/ -->
@@ -84,7 +86,7 @@ See also:
 
 
 <!-- ====================================================================== -->
-## Documentation
+### Documentation
 
 * [Overview of Microsoft Edge extensions](https://aka.ms/AboutEdgeAddons)
 * [Extension concepts and architecture](https://aka.ms/EdgeAddonsLearn)
@@ -97,6 +99,6 @@ See also:
 
 
 <!-- ====================================================================== -->
-## Edge-related issues other than extensions
+### Edge-related issues other than extensions
 
 For Microsoft Edge-related issues other than extensions, see [How to Report a Feedback/Bug to Microsoft Edge's Team?](https://answers.microsoft.com/en-us/microsoftedge/forum/all/how-to-report-a-feedbackbug-to-microsoft-edges/20cc8eb5-11bb-43b6-95d1-e004d41ef876)<!-- /en-us/ required -->

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ https://learn.microsoft.com/microsoft-edge/extensions-chromium/publish/contact-e
 https://github.com/microsoft/MicrosoftEdge-Extensions/blob/main/README.md#issues
 -->
 
-Use the [Issues](https://github.com/microsoft/MicrosoftEdge-Extensions/discussions) page of this **MicrosoftEdge-Extensions** repo for:
+Use the [Issues](https://github.com/microsoft/MicrosoftEdge-Extensions/issues) page of this **MicrosoftEdge-Extensions** repo for:
 
 * Communicating with the Extensions team:
   * Report bugs or issues about [Microsoft Edge Add-ons](https://microsoftedge.microsoft.com/addons/) (the store) that affect all Edge extension developers or all Microsoft Edge extension users.

--- a/README.md
+++ b/README.md
@@ -59,14 +59,14 @@ https://github.com/microsoft/MicrosoftEdge-Extensions/blob/main/README.md#discus
 
 Use the [Discussions](https://github.com/microsoft/MicrosoftEdge-Extensions/discussions) page of this **MicrosoftEdge-Extensions** repo for:
 
-* Discussing with the Extensions team:
+* Discussions with the Extensions team:
   * Follow the latest announcements and updates from the Microsoft Edge extensions team.
   * Request a feature for Edge extensions.
   * Discuss how to improve UI features that are at [Microsoft Edge Add-ons](https://microsoftedge.microsoft.com/addons/).
   * Discuss how to improve extension publishing, management and listing processes or workflows.
   * Provide feedback about features for extensions publishing, extensions management, or processes or workflows for extensions listings.
 
-* Discussing with other extension developers:
+* Discussions with other extension developers:
   * Discuss technical questions about developing an Edge extension.
   * Share best practices, tips, and tricks with other developers on building, publishing, managing, or acquiring more users for their browser extension.
   * Share ideas about features for Microsoft Edge extensions.

--- a/README.md
+++ b/README.md
@@ -8,15 +8,25 @@ The [Microsoft Edge Add-ons Developer](https://developer.microsoft.com/microsoft
 <!-- ====================================================================== -->
 ## About the MicrosoftEdge-Extensions repo
 
-Use this **MicrosoftEdge-Extensions** repo as a community space, to:
+Use this **MicrosoftEdge-Extensions** repo as a community space.
+
+**Code** tab:
 
 * Access resources and sample code to learn how to build Microsoft Edge extensions (add-ons).
 
+**Issues** tab:
+
+* Inquire about your Microsoft Edge add-ons developer account.
+
+* Inquire about the review status or certification status of your Edge extension after submitting the extension via Partner Center.
+
 * Connect with other extension developers about technical questions related to building Microsoft Edge add-ons.
 
-* Share inputs or suggestions to the Microsoft Edge add-ons engineering team on how to improve extension publishing, management and listing processes or workflows.
+* Report any bugs or issues about Microsoft Partner Center or the Edge Add-ons website which affect all developers or all Microsoft Edge users.
 
-* Report any bugs or issues about Microsoft Partner Center or the Edge Add-ons website which affect all developers or all Microsoft Edge users (rather than issues about a specific developer account or extension).
+**Discussions** tab:
+
+* Share inputs or suggestions to the Microsoft Edge add-ons engineering team on how to improve extension publishing, management and listing processes or workflows.
 
 * Provide early feedback to the Microsoft Edge add-ons engineering team about any new features for extensions publishing, extensions management, or processes or workflows for extensions listings.
 
@@ -31,7 +41,7 @@ The **MicrosoftEdge-Extensions** repo includes the following tabs:
 | Tab | Purpose |
 | ------------ | ------------ |
 | [Code](https://github.com/microsoft/MicrosoftEdge-Extensions/tree/main/Extension-samples) | Sample code for Microsoft Edge extensions (add-ons). |
-| [Issues](https://github.com/microsoft/MicrosoftEdge-Extensions/issues) | Use this forum to report bugs or suggest new features that could impact or benefit all Microsoft Edge extension developers. |
+| [Issues](https://github.com/microsoft/MicrosoftEdge-Extensions/issues) | Use this forum to report bugs or suggest new features that could impact or benefit all Microsoft Edge extension developers, or inquire about your developer account or extension status. |
 | [Discussions](https://github.com/microsoft/MicrosoftEdge-Extensions/discussions) | Use this forum to share questions or answer other developers' questions about building or publishing Microsoft Edge add-ons, follow the latest announcements and updates from the Microsoft Edge add-ons team, and share tips and tricks with other developers. |
 
 
@@ -56,7 +66,8 @@ You can follow what's happening with Microsoft Edge add-ons via [#EdgeExtensions
 
 You can also stay tuned to recent updates and announcements via the [Microsoft Edge Insider](https://techcommunity.microsoft.com/category/MicrosoftEdgeInsider) product community at Tech Community, or search there for [Edge extensions](https://techcommunity.microsoft.com/search?q=edge+extensions&location=category%3AMicrosoftEdgeInsider)<!-- 1269 --> or [Edge add-on](https://techcommunity.microsoft.com/search?q=edge+add-on&location=category%3AMicrosoftEdgeInsider).<!-- 1108 -->
 
-See also [Contact the Microsoft Edge extensions team](https://learn.microsoft.com/microsoft-edge/extensions-chromium/publish/contact-extensions-team).
+See also:
+* [Contact the Microsoft Edge extensions team](https://learn.microsoft.com/microsoft-edge/extensions-chromium/publish/contact-extensions-team)
 
 
 <!-- ====================================================================== -->
@@ -73,8 +84,6 @@ See also [Contact the Microsoft Edge extensions team](https://learn.microsoft.co
 
 
 <!-- ====================================================================== -->
-## Questions about a specific developer account or extension
+## Edge-related issues other than extensions
 
-Don't use the **Issues** tab or the **Discussions** tab in this repo for questions about a specific developer account or a specific extension.  For support about a specific Microsoft Edge add-ons developer account or a specific Edge extension, see [Contact the Microsoft Edge extensions team](https://learn.microsoft.com/microsoft-edge/extensions-chromium/publish/contact-extensions-team).
-
-For Microsoft Edge-related issues other than extensions, see [How to Report a Feedback/Bug to Microsoft Edge's Team?](https://answers.microsoft.com/en-us/microsoftedge/forum/all/how-to-report-a-feedbackbug-to-microsoft-edges/20cc8eb5-11bb-43b6-95d1-e004d41ef876)
+For Microsoft Edge-related issues other than extensions, see [How to Report a Feedback/Bug to Microsoft Edge's Team?](https://answers.microsoft.com/en-us/microsoftedge/forum/all/how-to-report-a-feedbackbug-to-microsoft-edges/20cc8eb5-11bb-43b6-95d1-e004d41ef876)<!-- /en-us/ required -->

--- a/README.md
+++ b/README.md
@@ -27,23 +27,18 @@ https://learn.microsoft.com/microsoft-edge/extensions-chromium/publish/contact-e
 https://github.com/microsoft/MicrosoftEdge-Extensions/blob/main/README.md#issues
 -->
 
-To report or discuss an issue about extensions, use the [Issues](https://github.com/microsoft/MicrosoftEdge-Extensions/issues) page in this **MicrosoftEdge-Extensions** repo.
+Use the [Issues](https://github.com/microsoft/MicrosoftEdge-Extensions/discussions) page of this **MicrosoftEdge-Extensions** repo for:
 
-Use the **Issues** page to:
+* Communicating with the Extensions team:
+  * Report bugs or issues about [Microsoft Edge Add-ons](https://microsoftedge.microsoft.com/addons/) (the store) that affect all Edge extension developers or all Microsoft Edge extension users.
+  * Report bugs or issues about Microsoft Partner Center that affect all Edge extension developers or all Microsoft Edge extension users.
+  * Suggest new features that could impact or benefit all Microsoft Edge extension developers.
+  * Inquire about your Partner Center developer account for Microsoft Edge extensions.
+  * Inquire about the review status or certification status of your Edge extension after submitting the extension via Partner Center.
 
-* Report bugs or issues about [Microsoft Edge Add-ons](https://microsoftedge.microsoft.com/addons/) (the store) that affect all Edge extension developers or all Microsoft Edge extension users.
-
-* Report bugs or issues about Microsoft Partner Center that affect all Edge extension developers or all Microsoft Edge extension users.
-
-* Inquire about your Partner Center developer account for Microsoft Edge extensions.
-
-* Inquire about the review status or certification status of your Edge extension after submitting the extension via Partner Center.
-
-* Suggest new features that could impact or benefit all Microsoft Edge extension developers.
-
-* Connect with other extension developers about technical questions related to building Microsoft Edge extensions.
-
-* Ask about aspects of extensions that affect all extension developers or all Microsoft Edge extension users.
+* Communicating with other extension developers:
+  * Connect with other extension developers about technical questions related to building Microsoft Edge extensions.
+  * Ask about aspects of extensions that affect all extension developers or all Microsoft Edge extension users.
 
 See also:
 * [GitHub Issues](https://docs.github.com/get-started/using-github/communicating-on-github#github-issues) in _Communicating on GitHub_.


### PR DESCRIPTION
Companion PR in Docs repo: https://github.com/MicrosoftDocs/edge-developer/pull/3460 - Remove email from "Contact the Microsoft Edge extensions team"

Rendered Readme for review:
* Readme for review: https://github.com/mikehoffms/MicrosoftEdge-Extensions/blob/user/mikehoffms/readme-contact/README.md
* Live Readme: https://github.com/microsoft/MicrosoftEdge-Extensions/blob/main/README.md
* Removed email contact; guide all developers through GitHub.
   * Removed h2 **Questions about a specific developer account or extension**, folded into h2 **Issues**. 
* Re-outlined to have an h2 for each of: **Code**; **Issues**; & **Discussions** pages of the repo.
* Sync'd:
   * **Contact** page >  h2 **Issues page in the MicrosoftEdge-Extensions repo**
   * **Readme** > h2 **Issues**
* Sync'd:
   * **Contact** page > h2 **Discussions page in the MicrosoftEdge-Extensions repo**
   * **Readme** > h2 **Discussions**
* Latest usage of site name [Microsoft Edge Add-ons], & you create an extension.
   * Updated link text from "add-ons" to "extensions".
* Linked to GitHub docs on when to use **Issues** vs. **Discussions**.

AB#57777601
