### PR TITLE
Add "Release notes" section in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Use this **MicrosoftEdge-Extensions** repo as a community space.  This repo cont
 <!-- ====================================================================== -->
 ## Websites
 
-[Microsoft Edge Add-ons](https://microsoftedge.microsoft.com/addons/Microsoft-Edge-Extensions-Home) is the store for Microsoft Edge extensions, where you can publish your Microsoft Edge extensions and make them available to Microsoft Edge users.
+As a Microsoft Edge extension developer, you use Partner Center to publish your Microsoft Edge extensions at the [Microsoft Edge Add-ons](https://microsoftedge.microsoft.com/addons/Microsoft-Edge-Extensions-Home) site, to make your extensions available to Microsoft Edge users.
 
 [Microsoft Edge Add-ons Developer](https://developer.microsoft.com/microsoft-edge/extensions/) is a central portal for information and resources for developing Microsoft Edge extensions.
 
@@ -56,7 +56,7 @@ https://github.com/microsoft/MicrosoftEdge-Extensions/blob/main/README.md#issues
 Use the [Issues](https://github.com/microsoft/MicrosoftEdge-Extensions/issues) page of this **MicrosoftEdge-Extensions** repo for:
 
 * Communicating with the Extensions team:
-  * Report bugs or issues about [Microsoft Edge Add-ons](https://microsoftedge.microsoft.com/addons/) (the store) that affect all Edge extension developers or all Microsoft Edge extension users.
+  * Report bugs or issues about the [Microsoft Edge Add-ons](https://microsoftedge.microsoft.com/addons/) site that affect all Edge extension developers or all Microsoft Edge extension users.
   * Report bugs or issues about Microsoft Partner Center that affect all Edge extension developers or all Microsoft Edge extension users.
   * Suggest new features that could impact or benefit all Microsoft Edge extension developers.
   * Inquire about your Partner Center developer account for Microsoft Edge extensions.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # About the MicrosoftEdge-Extensions repo
 <!-- https://github.com/microsoft/MicrosoftEdge-Extensions/blob/main/README.md -->
+<!-- links tested 2026/01/12 -->
 
 Use this **MicrosoftEdge-Extensions** repo as a community space.  This repo contains sample code, issues, and discussions about Microsoft Edge extensions (add-ons).
 
 **Contents:**
 * [Websites](#websites)
-* [Code](#code)
+* [Code](#coode)
 * [Issues](#issues)
 * [Discussions](#discussions)
 * [Stay connected](#stay-connected)
@@ -16,7 +17,7 @@ Use this **MicrosoftEdge-Extensions** repo as a community space.  This repo cont
 <!-- ====================================================================== -->
 ## Websites
 
-* The [Microsoft Edge Add-ons](https://microsoftedge.microsoft.com/addons/Microsoft-Edge-Extensions-Home) site - As a Microsoft Edge extension developer, you use Partner Center to publish an extension at this site, to make the extension available to Microsoft Edge users.
+* The [Microsoft Edge Add-ons](https://microsoftedge.microsoft.com) site - As a Microsoft Edge extension developer, you use Partner Center to publish an extension at this site, to make the extension available to Microsoft Edge users.
 
 * [Microsoft Edge Add-ons Developer](https://developer.microsoft.com/microsoft-edge/extensions/) - A central portal for information and resources for developing Microsoft Edge extensions.
 
@@ -24,7 +25,7 @@ Use this **MicrosoftEdge-Extensions** repo as a community space.  This repo cont
 <!-- ====================================================================== -->
 ## Code
 <!-- sync:
-https://learn.microsoft.com/microsoft-edge/extensions/samples#list-of-samples
+https://learn.microsoft.com/microsoft-edge/extensions/samples
 https://github.com/microsoft/MicrosoftEdge-Extensions/blob/main/README.md#code
 https://github.com/MicrosoftEdge/Demos/blob/main/README.md#microsoft-edge-extensions
 -->
@@ -35,15 +36,15 @@ This repo contains the following samples:
 
 | Name | Folder | Article |
 | --- | --- | --- |
-| Picture viewer pop-up webpage | [/picture-viewer-popup-webpage/](./Extension-samples/picture-viewer-popup-webpage/) | [Sample: Picture viewer pop-up webpage](https://learn.microsoft.com/microsoft-edge/extensions/getting-started/picture-viewer-popup-webpage) |
-| Picture inserter using content script | [/picture-inserter-content-script/](./Extension-samples/picture-inserter-content-script/) | [Sample: Picture inserter using content script](https://learn.microsoft.com/microsoft-edge/extensions/getting-started/picture-inserter-content-script) |
+| Picture viewer pop-up webpage | [/picture-viewer-popup-webpage/](./Extension-samples/picture-viewer-popup-webpage/) | [Sample: Picture viewer pop-up webpage](https://learn.microsoft.com/microsoft-edge/extensions/samples/picture-viewer-popup-webpage) |
+| Picture inserter using content script | [/picture-inserter-content-script/](./Extension-samples/picture-inserter-content-script/) | [Sample: Picture inserter using content script](https://learn.microsoft.com/microsoft-edge/extensions/samples/picture-inserter-content-script) |
 
-The files in [/assets/](./assets/) are for [Use the Microsoft Edge Add-ons badge to promote your add-on](https://learn.microsoft.com/microsoft-edge/extensions/publish/add-ons-badge.md).
+The files in [/assets/](./assets/) are for [Use the Microsoft Edge Add-ons badge to promote your add-on](https://learn.microsoft.com/microsoft-edge/extensions/publish/add-ons-badge/).
 
 The files in [/TestCrxPackages/](./TestCrxPackages/) are test extension packages for testing the update feature.
 
 See also:
-* [List of samples](https://learn.microsoft.com/microsoft-edge/extensions/samples#list-of-samples) in _Samples for Microsoft Edge extensions_.  Includes samples that are in the **MicrosoftEdge / Demos** repo.
+* [Samples for Microsoft Edge extensions](https://learn.microsoft.com/microsoft-edge/extensions/samples).  Also lists extension samples that are in the **MicrosoftEdge / Demos** repo.
 
 
 <!-- ====================================================================== -->
@@ -56,7 +57,7 @@ https://github.com/microsoft/MicrosoftEdge-Extensions/blob/main/README.md#issues
 Use the [Issues](https://github.com/microsoft/MicrosoftEdge-Extensions/issues) page of this **MicrosoftEdge-Extensions** repo for:
 
 * Communicating with the Extensions team:
-  * Report bugs or issues about the [Microsoft Edge Add-ons](https://microsoftedge.microsoft.com/addons/) site that affect all Edge extension developers or all Microsoft Edge extension users.
+  * Report bugs or issues about the [Microsoft Edge Add-ons](https://microsoftedge.microsoft.com) site that affect all Edge extension developers or all Microsoft Edge extension users.
   * Report bugs or issues about Microsoft Partner Center that affect all Edge extension developers or all Microsoft Edge extension users.
   * Suggest new features that could impact or benefit all Microsoft Edge extension developers.
   * Inquire about your Partner Center developer account for Microsoft Edge extensions.
@@ -69,7 +70,24 @@ Use the [Issues](https://github.com/microsoft/MicrosoftEdge-Extensions/issues) p
 See also:
 * [GitHub Issues](https://docs.github.com/get-started/using-github/communicating-on-github#github-issues) in _Communicating on GitHub_.
 * [Scenarios for issues](https://docs.github.com/get-started/using-github/communicating-on-github#scenarios-for-issues) in _Communicating on GitHub_.
-* [How to Report a Feedback/Bug to Microsoft Edge's Team?](https://answers.microsoft.com/en-us/microsoftedge/forum/all/how-to-report-a-feedbackbug-to-microsoft-edges/20cc8eb5-11bb-43b6-95d1-e004d41ef876)<!-- /en-us/ required --> - use for Microsoft Edge-related issues other than extensions.
+
+
+<!-- ------------------------------ -->
+#### Edge-related issues other than extensions
+
+To view existing questions about Microsoft Edge:
+
+1. Go to [Ask a question](https://learn.microsoft.com/en-us/answers/questions/ask/) at **Microsoft Q&A**.
+
+1. Click **Tag**, and then find **Microsoft Edge**.
+
+   You arrive at [Microsoft Edge](https://learn.microsoft.com/en-us/answers/tags/781/microsoft-edge) at **Microsoft Q&A**.
+
+To enter a new question about Microsoft Edge:
+
+1. Go to [Ask a question](https://learn.microsoft.com/en-us/answers/questions/ask/) at **Microsoft Q&A**.
+
+1. In the **Select a tag** dropdown list, select **Microsoft Edge**.
 
 
 <!-- ====================================================================== -->
@@ -84,7 +102,7 @@ Use the [Discussions](https://github.com/microsoft/MicrosoftEdge-Extensions/disc
 * Discussions with the Extensions team:
   * Follow the latest announcements and updates from the Microsoft Edge extensions team.
   * Request a feature for Edge extensions.
-  * Discuss how to improve UI features that are at [Microsoft Edge Add-ons](https://microsoftedge.microsoft.com/addons/).
+  * Discuss how to improve UI features that are at [Microsoft Edge Add-ons](https://microsoftedge.microsoft.com).
   * Discuss how to improve extension publishing, management and listing processes or workflows.
   * Provide feedback about features for extensions publishing, extensions management, or processes or workflows for extensions listings.
 
@@ -101,10 +119,11 @@ See also:
 <!-- ====================================================================== -->
 ## Stay connected
 
-You can follow what's happening with Microsoft Edge extensions via [#EdgeExtensions at Twitter](https://x.com/search?q=%23EdgeExtensions&src=typed_query&f=live).
-<!-- possible link: https://x.com/msedgedev/ -->
+You can follow what's happening with Microsoft Edge extensions via:
+* [#EdgeExtensions at Twitter](https://x.com/search?q=%23EdgeExtensions&src=typed_query&f=live)
+<!-- * [Microsoft Edge Dev](https://x.com/msedgedev/) -->
 
-You can also stay tuned to recent updates and announcements via the [Microsoft Edge Insider](https://techcommunity.microsoft.com/category/MicrosoftEdgeInsider) product community at Tech Community, or search there for [Edge extensions](https://techcommunity.microsoft.com/search?q=edge+extensions&location=category%3AMicrosoftEdgeInsider)<!-- 1269 --> or [Edge add-on](https://techcommunity.microsoft.com/search?q=edge+add-on&location=category%3AMicrosoftEdgeInsider).<!-- 1108 -->
+You can also stay tuned to recent updates and announcements via the [Microsoft Edge Insider](https://techcommunity.microsoft.com/category/MicrosoftEdgeInsider) product community at Tech Community, or search there for [Edge extensions](https://techcommunity.microsoft.com/search?q=edge+extensions&location=category%3AMicrosoftEdgeInsider)<!-- 1291 Results --> or [Edge add-on](https://techcommunity.microsoft.com/search?q=edge+add-on&location=category%3AMicrosoftEdgeInsider)<!-- 1118 Results -->.
 
 See also:
 * [Contact the Microsoft Edge extensions team](https://learn.microsoft.com/microsoft-edge/extensions/contact)
@@ -113,15 +132,13 @@ See also:
 <!-- ====================================================================== -->
 ## Documentation
 
-* [Overview of Microsoft Edge extensions](https://aka.ms/AboutEdgeAddons)
-* [Extension concepts and architecture](https://aka.ms/EdgeAddonsLearn)
+* [Overview of Microsoft Edge extensions](https://aka.ms/AboutEdgeAddons)<!-- aka link is noted in the destination .md file -->
+* [Extension concepts and architecture](https://aka.ms/EdgeAddonsLearn)<!-- aka link is noted in the destination .md file -->
 * [Supported APIs for Microsoft Edge extensions](https://learn.microsoft.com/microsoft-edge/extensions/developer-guide/api-support)
 * [Register as a Microsoft Edge extension developer](https://learn.microsoft.com/microsoft-edge/extensions/publish/create-dev-account)
-<!-- aka links are noted in the destination .md file -->
 
 
 <!-- ====================================================================== -->
 ## Release notes
 
-* [Release notes for Microsoft Edge extensions](https://aka.ms/EdgeAddonsReleaseNotes)
-<!-- aka links are noted in the destination .md file -->
+* [Release notes for Microsoft Edge extensions](https://aka.ms/EdgeAddonsReleaseNotes)<!-- aka link is noted in the destination .md file -->

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ Use this **MicrosoftEdge-Extensions** repo as a community space.  This repo cont
 <!-- ====================================================================== -->
 ## Websites
 
-As a Microsoft Edge extension developer, you use Partner Center to publish your Microsoft Edge extensions at the [Microsoft Edge Add-ons](https://microsoftedge.microsoft.com/addons/Microsoft-Edge-Extensions-Home) site, to make your extensions available to Microsoft Edge users.
+* The [Microsoft Edge Add-ons](https://microsoftedge.microsoft.com/addons/Microsoft-Edge-Extensions-Home) site - As a Microsoft Edge extension developer, you use Partner Center to publish your extension at this site, to make the extension available to Microsoft Edge users.
 
-[Microsoft Edge Add-ons Developer](https://developer.microsoft.com/microsoft-edge/extensions/) is a central portal for information and resources for developing Microsoft Edge extensions.
+* [Microsoft Edge Add-ons Developer](https://developer.microsoft.com/microsoft-edge/extensions/) - A central portal for information and resources for developing Microsoft Edge extensions.
 
 
 <!-- ====================================================================== -->

--- a/README.md
+++ b/README.md
@@ -1,6 +1,20 @@
 # About the MicrosoftEdge-Extensions repo
+<!-- https://github.com/microsoft/MicrosoftEdge-Extensions/blob/main/README.md -->
 
 Use this **MicrosoftEdge-Extensions** repo as a community space.  This repo contains sample code, issues, and discussions about Microsoft Edge extensions (add-ons).
+
+**Contents:**
+* [Websites](#websites)
+* [Code](#code)
+* [Issues](#issues)
+* [Discussions](#discussions)
+* [Stay connected](#stay-connected)
+* [Documentation](#documentation)
+* [Release notes](#release-notes)
+
+
+<!-- ====================================================================== -->
+## Websites
 
 [Microsoft Edge Add-ons](https://microsoftedge.microsoft.com/addons/Microsoft-Edge-Extensions-Home) is the store for Microsoft Edge extensions, where you can publish your Microsoft Edge extensions and make them available to Microsoft Edge users.
 
@@ -55,6 +69,7 @@ Use the [Issues](https://github.com/microsoft/MicrosoftEdge-Extensions/issues) p
 See also:
 * [GitHub Issues](https://docs.github.com/get-started/using-github/communicating-on-github#github-issues) in _Communicating on GitHub_.
 * [Scenarios for issues](https://docs.github.com/get-started/using-github/communicating-on-github#scenarios-for-issues) in _Communicating on GitHub_.
+* [How to Report a Feedback/Bug to Microsoft Edge's Team?](https://answers.microsoft.com/en-us/microsoftedge/forum/all/how-to-report-a-feedbackbug-to-microsoft-edges/20cc8eb5-11bb-43b6-95d1-e004d41ef876)<!-- /en-us/ required --> - use for Microsoft Edge-related issues other than extensions.
 
 
 <!-- ====================================================================== -->
@@ -110,9 +125,3 @@ See also:
 
 * [Release notes for Microsoft Edge extensions](https://aka.ms/EdgeAddonsReleaseNotes)
 <!-- aka links are noted in the destination .md file -->
-
-
-<!-- ====================================================================== -->
-## Edge-related issues other than extensions
-
-For Microsoft Edge-related issues other than extensions, see [How to Report a Feedback/Bug to Microsoft Edge's Team?](https://answers.microsoft.com/en-us/microsoftedge/forum/all/how-to-report-a-feedbackbug-to-microsoft-edges/20cc8eb5-11bb-43b6-95d1-e004d41ef876)<!-- /en-us/ required -->

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Use this **MicrosoftEdge-Extensions** repo as a community space.  This repo cont
 <!-- ====================================================================== -->
 ## Websites
 
-* The [Microsoft Edge Add-ons](https://microsoftedge.microsoft.com/addons/Microsoft-Edge-Extensions-Home) site - As a Microsoft Edge extension developer, you use Partner Center to publish your extension at this site, to make the extension available to Microsoft Edge users.
+* The [Microsoft Edge Add-ons](https://microsoftedge.microsoft.com/addons/Microsoft-Edge-Extensions-Home) site - As a Microsoft Edge extension developer, you use Partner Center to publish an extension at this site, to make the extension available to Microsoft Edge users.
 
 * [Microsoft Edge Add-ons Developer](https://developer.microsoft.com/microsoft-edge/extensions/) - A central portal for information and resources for developing Microsoft Edge extensions.
 

--- a/README.md
+++ b/README.md
@@ -102,10 +102,14 @@ See also:
 * [Extension concepts and architecture](https://aka.ms/EdgeAddonsLearn)
 * [Supported APIs for Microsoft Edge extensions](https://learn.microsoft.com/microsoft-edge/extensions/developer-guide/api-support)
 * [Register as a Microsoft Edge extension developer](https://learn.microsoft.com/microsoft-edge/extensions/publish/create-dev-account)
-* [Defining match patterns for an extension to access file URLs](https://learn.microsoft.com/microsoft-edge/extensions/enterprise/match-patterns)
-* [Roadmap for Microsoft Edge extensions](https://aka.ms/EdgeAddonsRoadmap)
-* [Released features for Microsoft Edge extensions](https://aka.ms/EdgeAddonsReleaseNotes)
-<!-- the 4 aka links are noted in the destination .md file -->
+<!-- aka links are noted in the destination .md file -->
+
+
+<!-- ====================================================================== -->
+## Release notes
+
+* [Release notes for Microsoft Edge extensions](https://aka.ms/EdgeAddonsReleaseNotes)
+<!-- aka links are noted in the destination .md file -->
 
 
 <!-- ====================================================================== -->


### PR DESCRIPTION
Related PRs:
* https://github.com/MicrosoftDocs/edge-developer/pull/3665
* https://github.com/microsoft/MicrosoftEdge-Extensions/pull/486

Rendered article sections for review:

* **Readme**
   * `~/README.md`
   * PR branch preview: https://github.com/mikehoffms/MicrosoftEdge-Extensions/blob/user/mikehoffms/readme-relnotes/README.md
   * Before/live: https://github.com/microsoft/MicrosoftEdge-Extensions/blob/main/README.md
   * Added h2 section **Release notes** instead of a link in h2 section **Documentation**.
   * Added TOC.
   * Tested all links; updated some links.
   * Removed [match patterns] article link; too specific.
   * Demoted h2 section **Edge-related issues other than extensions** to h4 within h2 section **Issues**.

AB#60704745
